### PR TITLE
Custom pages folder setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-alias-imports": "^1.0.5",
     "gatsby-plugin-manifest": "^2.2.39",
     "gatsby-plugin-offline": "^3.0.32",
+    "gatsby-plugin-page-creator": "^2.1.40",
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sharp": "^2.4.3",
     "gatsby-source-filesystem": "^2.1.46",

--- a/routes.js
+++ b/routes.js
@@ -1,0 +1,20 @@
+module.exports = [
+  {
+    resolve: `gatsby-plugin-page-creator`,
+    options: {
+      path: `${__dirname}/src/pages/index`,
+    },
+  },
+  {
+    resolve: `gatsby-plugin-page-creator`,
+    options: {
+      path: `${__dirname}/src/pages/page-2`,
+    },
+  },
+  {
+    resolve: `gatsby-plugin-page-creator`,
+    options: {
+      path: `${__dirname}/src/pages/404`,
+    },
+  },
+]

--- a/routes.js
+++ b/routes.js
@@ -2,12 +2,6 @@ module.exports = [
   {
     resolve: `gatsby-plugin-page-creator`,
     options: {
-      path: `${__dirname}/src/pages/index`,
-    },
-  },
-  {
-    resolve: `gatsby-plugin-page-creator`,
-    options: {
       path: `${__dirname}/src/pages/page-2`,
     },
   },

--- a/src/pages/404/index.js
+++ b/src/pages/404/index.js
@@ -1,7 +1,7 @@
-import React from "react"
+import React from 'react'
 
-import Layout from "../components/layout"
-import SEO from "../components/seo"
+import Layout from '../../components/layout'
+import SEO from '../../components/seo'
 
 const NotFoundPage = () => (
   <Layout>

--- a/src/pages/page-2/index.js
+++ b/src/pages/page-2/index.js
@@ -1,8 +1,8 @@
-import React from "react"
-import { Link } from "gatsby"
+import React from 'react'
+import { Link } from 'gatsby'
 
-import Layout from "../components/layout"
-import SEO from "../components/seo"
+import Layout from '../../components/layout'
+import SEO from '../../components/seo'
 
 const SecondPage = () => (
   <Layout>


### PR DESCRIPTION
Setup to overwrite Gatsby default pages routes and use pages components inside folders instead of file name routing

The only thing is the index page **must** be a `index.js` at the root of `src/pages`